### PR TITLE
added post losers

### DIFF
--- a/graphql/postLosers.js
+++ b/graphql/postLosers.js
@@ -1,0 +1,43 @@
+const firebase = require("../firebase.js");
+const db = firebase.db;
+const admin = firebase.admin;
+
+function postLosers(userHandles) {
+  var ref = db.collection("users");
+  userHandles.map(async user => {
+    const document = ref.doc(user);
+    const data = await document.get();
+    if (data["_createTime"] === undefined) {
+      document
+        .set({
+          wins: 0,
+          losses: 1,
+          winStreak: 0,
+          lossStreak: 1
+        })
+        .then(() => {
+          console.log(user, " successfully written!");
+        })
+        .catch(error => {
+          console.error("Error writing user: ", error);
+        });
+    } else {
+      document
+        .update({
+          losses: admin.firestore.FieldValue.increment(1),
+          lossStreak: admin.firestore.FieldValue.increment(1),
+          winStreak: 0
+        })
+        .then(() => {
+          console.log(user, " successfully updated!");
+        })
+        .catch(error => {
+          console.error("Error writing user: ", error);
+        });
+    }
+  });
+
+  return true;
+}
+
+module.exports = postLosers;

--- a/graphql/root.js
+++ b/graphql/root.js
@@ -3,13 +3,15 @@ const getBottomOfLeaderboard = require("./getBottomOfLeaderboard.js");
 const getTopWinStreaks = require("./getTopWinStreaks.js");
 const getTopLoseStreaks = require("./getTopLoseStreaks.js");
 const postWinners = require("./postWinners.js");
+const postLosers = require("./postLosers.js");
 
 const root = {
   mostWins: ({ numUsers }) => getTopOfLeaderboard(numUsers),
   mostLosses: ({ numUsers }) => getBottomOfLeaderboard(numUsers),
   highestWinStreaks: ({ numUsers }) => getTopWinStreaks(numUsers),
   highestLoseStreaks: ({ numUsers }) => getTopLoseStreaks(numUsers),
-  winners: ({ userHandles }) => postWinners(userHandles)
+  winners: ({ userHandles }) => postWinners(userHandles),
+  losers: ({ userHandles }) => postLosers(userHandles)
 };
 
 module.exports = root;

--- a/graphql/schema.js
+++ b/graphql/schema.js
@@ -18,6 +18,7 @@ const schema = buildSchema(`
 
   type Mutation {
     winners(userHandles: [String]!): Boolean
+    losers(userHandles: [String]!): Boolean
   }
 `);
 

--- a/graphql_tests/postLosersTest.js
+++ b/graphql_tests/postLosersTest.js
@@ -1,0 +1,30 @@
+const firebase = require("../firebase.js");
+const db = firebase.db;
+const admin = firebase.admin;
+const postLosers = require("../graphql/postLosers.js");
+const should = require("chai").should();
+
+describe("postLosers", function() {
+  it("should return true for adding user to db", async function() {
+    response = await postLosers(["nash"]);
+    revertProdData(["nash"]);
+    response.should.equal(true);
+  });
+});
+
+async function revertProdData(userHandles) {
+  var ref = db.collection("users");
+  const document = ref.doc(userHandles[0]);
+  document
+    .update({
+      losses: admin.firestore.FieldValue.increment(-1),
+      lossStreak: admin.firestore.FieldValue.increment(-1),
+      winStreak: 0
+    })
+    .then(function() {
+      console.log("successfully updated!");
+    })
+    .catch(function(error) {
+      console.error("Error writing user: ", error);
+    });
+}


### PR DESCRIPTION
Update the database for losing users. An array of slack handles will be passed in as input. Those who are already in the database will have their loss total incremented by 1, while new users will have a new entry created in the db.